### PR TITLE
Add <br/> tag to the redirect note to avoid being covered by page TOC

### DIFF
--- a/action.php
+++ b/action.php
@@ -80,7 +80,7 @@ class action_plugin_pageredirect extends DokuWiki_Action_Plugin {
 				if (isset($_SESSION[DOKU_COOKIE]['redirect']) && $_SESSION[DOKU_COOKIE]['redirect'] != '') {
 					// we were redirected from another page, show it!
 					$page = $_SESSION[DOKU_COOKIE]['redirect'];
-					echo '<div class="noteredirect">'.sprintf($this->getLang('redirected_from'), '<a href="'.wl(':'.$page, Array('redirect' => 'no'), TRUE, '&').'" class="wikilink1" title="'.$page.'">'.$page.'</a>').'</div>';
+					echo '<div class="noteredirect">'.sprintf($this->getLang('redirected_from'), '<a href="'.wl(':'.$page, Array('redirect' => 'no'), TRUE, '&').'" class="wikilink1" title="'.$page.'">'.$page.'</a>').'</div><br/>';
 					unset($_SESSION[DOKU_COOKIE]['redirect']);
 
 					return true;


### PR DESCRIPTION
The notice for the Redirected page is covered by the automatically generated table of contents. Adding a break tag after the div fixes this.
