### PR TITLE
Basic support for external redirects + fixes for #5 and #6

### DIFF
--- a/action.php
+++ b/action.php
@@ -50,12 +50,6 @@ class action_plugin_pageredirect extends DokuWiki_Action_Plugin {
 			// verify metadata currency
 			if (@filemtime(metaFN($ID,'.meta')) < @filemtime(wikiFN($ID))) { return; }
 
-			if (!headers_sent() && $this->getConf('show_note')) {
-				// remember to show note about being redirected from another page
-				session_start();
-				$_SESSION[DOKU_COOKIE]['redirect'] = $ID;
-			}
-
 			// preserve #section from $page
 			list($page, $section) = explode('#', $page, 2);
 			if (isset($section)) {
@@ -64,9 +58,20 @@ class action_plugin_pageredirect extends DokuWiki_Action_Plugin {
 				$section = '';
 			}
 
+			// prepare link for internal redirects, keep external targets
+			if (!preg_match('#^(https?)://#i', $page)) {
+				$page = wl($page, array('redirect' => $redirect), TRUE, '&');
+
+				if (!headers_sent() && $this->getConf('show_note')) {
+					// remember to show note about being redirected from another page
+					session_start();
+					$_SESSION[DOKU_COOKIE]['redirect'] = $ID;
+				}
+			}
+
 			// redirect
 			header("HTTP/1.1 301 Moved Permanently");
-			header("Location: ".wl($page, Array('redirect' => $redirect), TRUE, '&'). $section);
+			header("Location: ".$page.$section);
 			exit();
 		}
 	}

--- a/syntax.php
+++ b/syntax.php
@@ -38,9 +38,16 @@ class syntax_plugin_pageredirect extends DokuWiki_Syntax_Plugin {
 			# ~~REDIRECT>PAGE~~
 			$page = substr($match, 11, -2);
 		}
+		$page=trim($page);
+
+		if (!preg_match('#^(https?)://#i', $page)) {
+			$link = html_wikilink($page);
+		} else {
+			$link = '<a href="'.hsc($page).'" class="urlextern">'.hsc($page).'</a>';
+		}
 
 		// prepare message here instead of in render
-		$message = '<div class="noteredirect">'.sprintf($this->getLang('redirect_to'), html_wikilink($page)).'</div>';
+		$message = '<div class="noteredirect">'.sprintf($this->getLang('redirect_to'), $link).'</div>';
 
 		return array($page, $message);
 	}


### PR DESCRIPTION
Until now, only redirects to DokuWiki pages have been supported.  This PR adds basic support for redirects to (external) URLs, following the same syntax:

```
~~REDIRECT>https://example.com~~
#redirect https://dokuwiki.org
```

Additionally, fixes for the following two issues are included as well (can be merged separately, if needed):
- #5, see d77260f
- #6, see a693d6b

If you prefer a linear history, I can rebase the individually merged commits onto the current master.
