### PR TITLE
Display pagename if heading is undefined

### DIFF
--- a/action.php
+++ b/action.php
@@ -110,7 +110,7 @@ class action_plugin_pageredirect extends DokuWiki_Action_Plugin {
 			if (isset($_SESSION[DOKU_COOKIE]['redirect']) && $_SESSION[DOKU_COOKIE]['redirect'] != '') {
 				// we were redirected from another page, show it!
 				$page  = cleanID($_SESSION[DOKU_COOKIE]['redirect']);
-				$title = hsc(useHeading('navigation') ? p_get_first_heading($page) : $page);
+				$title = hsc(useHeading('navigation') && p_get_first_heading($page) ? p_get_first_heading($page) : $page);
 				echo '<div class="noteredirect">'.sprintf($this->getLang('redirected_from'), '<a href="'.wl(':'.$page, array('redirect' => 'no'), TRUE, '&').'" class="wikilink1" title="'.$page.'">'.$title.'</a>').'</div><br/>';
 				unset($_SESSION[DOKU_COOKIE]['redirect']);
 


### PR DESCRIPTION
If useHeading option is set, and if heading of redirected page is
empty, displays __pagename__ instead of __heading__ in note. 
* Suggested in issue #9
* It will fix issues #9 and #13.