### PR TITLE
Partial support for backlinks with redirects

### DIFF
--- a/_test/backlinks.test.php
+++ b/_test/backlinks.test.php
@@ -1,0 +1,27 @@
+<?php
+
+require_once __DIR__ . '/test_abstract.php';
+
+/**
+ * test that metadata is correctly added to the index to support backlinks
+ *
+ * @group plugin_pageredirect
+ */
+class plugin_pageredirect_test_backlinks extends plugin_pageredirect_test_abstract {
+
+    public function test_simple_redirect() {
+        $link_from = 'link_from';
+        $orig_target = 'link_target';
+        $redirect_target = 'redirect_target';
+
+        saveWikiText($orig_target, '#redirect '.$redirect_target, 'created');
+        idx_addPage($orig_target);
+
+        saveWikiText($link_from, 'A link to [[:'.$orig_target.']].', 'created');
+        idx_addPage($link_from);
+
+
+        $this->assertEquals(array($link_from), ft_backlinks($orig_target));
+        $this->assertEquals(array($link_from), ft_backlinks($redirect_target));
+    }
+}

--- a/action.php
+++ b/action.php
@@ -174,7 +174,8 @@ class action_plugin_pageredirect extends DokuWiki_Action_Plugin {
     }
 
     private function get_metadata($ID) {
-        $metadata = p_get_metadata($ID, 'relation isreplacedby');
+        // make sure we always get current metadata, but simple cache logic (i.e. render when page is newer than metadata) is enough
+        $metadata = p_get_metadata($ID, 'relation isreplacedby', METADATA_RENDER_USING_SIMPLE_CACHE|METADATA_RENDER_UNLIMITED);
 
         // legacy compat
         if(is_string($metadata)) {


### PR DESCRIPTION
In response to #3, this adds partial support for backlinks. The support is partial in the sense that the index is only updated when the page containing the link is updated and not when a new redirect is created. Consider the following example: A links to B. Now a redirect is created from B to C. C won't list A as page linking to C unless A is updated.

I'm not really sure how to fix this cleanly. As noted in the source, a possible fix could work as follows: When adding a page to the index that contains a redirect, all pages linking to that page are found and re-indexing them is triggered by deleting their `.indexed` meta-file. Alternatively, it could be possible to update their index directly, but this is a bit problematic as the originally saved values cannot be easily retrieved externally (even though they are available). If the index should only be correct for the target page, the `renameMetaValue`-method of the indexer could be used. If you want to find the pages linking to the current page, make sure you do not use `ft_backlinks`, but the underlying method of the indexer directly as `ft_backlinks` respects ACLs.

Further, chained redirects are not considered, too.
