### PR TITLE
Fix metadata & Move plugin support

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -124,7 +124,11 @@ class syntax_plugin_pageredirect extends DokuWiki_Syntax_Plugin {
         if($format == 'metadata') {
             // add redirection to metadata
             $renderer->meta['relation']['isreplacedby'] = $data;
-            $renderer->meta['relation']['references'][$data[0]] = page_exists($data[0]);
+            if (!$data[1]) {
+                $page = preg_split("/\?|#/", $data[0])[0];
+                $renderer->meta['relation']['references'][$page] = page_exists($page);
+            }
+
             return true;
         }
 


### PR DESCRIPTION
  * Fix previous PR's problem. Previous code did not check if link is external or has anchor, resulting in wrong metadata stored in page. (I missed that, sorry.)
  * Adds "move" plugin support.

I tested this with many link types(internal or have anchor) and move cases(change namespace, change pagenames, do both, mass page moves, ...), but if you think I missed something please comment here. I'll fix that.