### PR TITLE
Update action.php to fix warning (issue #44).

### DIFF
--- a/action.php
+++ b/action.php
@@ -71,7 +71,7 @@ class action_plugin_pageredirect extends DokuWiki_Action_Plugin {
         }
 
         // preserve #section from $page
-        list($page, $section) = explode('#', $page, 2);
+        list($page, $section) = array_pad(explode('#', $page, 2),2,null);
         if(isset($section)) {
             $section = '#' . $section;
         } else {


### PR DESCRIPTION
```php
PHP Warning:  Undefined array key 1 in /home/domain/public_html/lib/plugins/pageredirect/action.php on line 74
```

- PHP 8.1
- DokuWiki 2023-04-04a "Jack Jackrum"
- Pageredirect Plugin 2022-11-20

In `action.php`, line 74, I have changed:
```php
list($page, $section) = explode('#', $page, 2);
```
to
```php
list($page, $section) = array_pad(explode('#', $page, 2), 2, null);
```
It works, redirect works fine, and error.log disappears.

About [PHP array_pad](https://www.php.net/manual/function.array-pad.php).