### PR TITLE
Create workflow to create tag on plugin.info.txt change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+# Create release on change to plugin.info.txt version line
+# https://github.com/dokuwiki/dokuwiki/issues/3951
+#
+# Requires DOKUWIKI_USER and DOKUWIKI_PASS secrets be set in GitHub Actions
+
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "*.info.txt"
+
+jobs:
+  release:
+    name: Release
+    # https://github.com/dokuwiki/dokuwiki/pull/3966
+    uses: glensc/dokuwiki/.github/workflows/plugin-release.yml@39431875f734bddc35cc6b4a899bbfdec97e8aba
+    secrets:
+      DOKUWIKI_USER: ${{ secrets.DOKUWIKI_USER }}
+      DOKUWIKI_PASS: ${{ secrets.DOKUWIKI_PASS }}
+
+# vim:ts=2:sw=2:et


### PR DESCRIPTION
Adopt:
- https://github.com/glensc/dokuwiki-plugin-slacknotifier/blob/965547d96989413f04fbc102f2225438efb86bd7/.github/workflows/release.yml

Refs:
- https://github.com/dokuwiki/dokuwiki/issues/3951
- https://github.com/saggi-dw/dokuwiki-plugin-htmlok/pull/10

----

Uses:
- https://github.com/dokuwiki/dokuwiki/pull/3966

Requires `DOKUWIKI_USER` and `DOKUWIKI_PASS` secrets be set in GitHub Actions:
- https://github.com/glensc/dokuwiki-plugin-pageredirect/settings/secrets/actions

The flow is that you:
1. setup the secrets
2. merge this pr

if you modify plugin.info.txt and set new version, the action will make release with the value of `date` field.